### PR TITLE
Update README.md to add Next-themes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Twitter Spaces Host and Speaker's Lounge
    ```console
    $ yarn
    ```
+   
+   There is also [next-themes](https://www.npmjs.com/package/next-themes) being used and it might give error, in that case:
+   
+   ```console
+   $ yarn add next-themes
+   ```
 
 5. Run the project
 


### PR DESCRIPTION
Added resolution to an error which occurs because the project is using next-themes and the dependencies for it are not getting installed by default

This error occurred twice so I am adding it to the docs in case such scenario arises in the future